### PR TITLE
Epel option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,34 @@ bundler_args: --without development
 before_install: rm Gemfile.lock || true
 script: "bundle exec rake test"
 rvm:
+  - 1.8.7
   - 1.9.3
   - 2.0.0
+  - 2.1.0
+  - 2.3.1
 env:
-  - PUPPET_GEM_VERSION="~> 2.7.0"
-  - PUPPET_GEM_VERSION="~> 3.1.0"
-  - PUPPET_GEM_VERSION="~> 3.2.0"
-  - PUPPET_GEM_VERSION="~> 3.3.0"
-  - PUPPET_GEM_VERSION="~> 3.4.0"
-  - PUPPET_GEM_VERSION="~> 3.5.0"
-matrix:
-  exclude:
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 2.7.0"
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 2.7.0"
+  matrix:
+    - PUPPET_GEM_VERSION="~> 3.1.0"
+    - PUPPET_GEM_VERSION="~> 3.2.0"
+    - PUPPET_GEM_VERSION="~> 3.3.0"
+    - PUPPET_GEM_VERSION="~> 3.4.0"
+    - PUPPET_GEM_VERSION="~> 3.5.0"
+    - PUPPET_GEM_VERSION="~> 3.6.0"
+    - PUPPET_GEM_VERSION="~> 3.7.0"
+    - PUPPET_GEM_VERSION="~> 3.8.0"
+    - PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
+    - PUPPET_GEM_VERSION="~> 4.0.0"
+    - PUPPET_GEM_VERSION="~> 4.1.0"
+    - PUPPET_GEM_VERSION="~> 4.2.0"
+    - PUPPET_GEM_VERSION="~> 4.3.0"
+    - PUPPET_GEM_VERSION="~> 4.4.0"
+    - PUPPET_GEM_VERSION="~> 4.5.0"
+    - PUPPET_GEM_VERSION="~> 4.6.0"
+    - PUPPET_GEM_VERSION="~> 4.7.0"
+    - PUPPET_GEM_VERSION="~> 4.8.0"
+    - PUPPET_GEM_VERSION="~> 4"
+    exclude:
+      - rvm: 2.0.0
+        env: PUPPET_GEM_VERSION="~> 3.1.0"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,6 @@ matrix:
     - rvm: 2.0.0
       env: PUPPET_GEM_VERSION="~> 3.1.0"
     - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.0.0"
+      env: PUPPET_GEM_VERSION="=> 4.0.0"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,28 +9,26 @@ rvm:
   - 2.1.0
   - 2.3.1
 env:
-  matrix:
-    - PUPPET_GEM_VERSION="~> 3.1.0"
-    - PUPPET_GEM_VERSION="~> 3.2.0"
-    - PUPPET_GEM_VERSION="~> 3.3.0"
-    - PUPPET_GEM_VERSION="~> 3.4.0"
-    - PUPPET_GEM_VERSION="~> 3.5.0"
-    - PUPPET_GEM_VERSION="~> 3.6.0"
-    - PUPPET_GEM_VERSION="~> 3.7.0"
-    - PUPPET_GEM_VERSION="~> 3.8.0"
-    - PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-    - PUPPET_GEM_VERSION="~> 4.0.0"
-    - PUPPET_GEM_VERSION="~> 4.1.0"
-    - PUPPET_GEM_VERSION="~> 4.2.0"
-    - PUPPET_GEM_VERSION="~> 4.3.0"
-    - PUPPET_GEM_VERSION="~> 4.4.0"
-    - PUPPET_GEM_VERSION="~> 4.5.0"
-    - PUPPET_GEM_VERSION="~> 4.6.0"
-    - PUPPET_GEM_VERSION="~> 4.7.0"
-    - PUPPET_GEM_VERSION="~> 4.8.0"
-    - PUPPET_GEM_VERSION="~> 4"
-    exclude:
-      - rvm: 2.0.0
-        env: PUPPET_GEM_VERSION="~> 3.1.0"
+  - PUPPET_GEM_VERSION="~> 3.1.0"
+  - PUPPET_GEM_VERSION="~> 3.2.0"
+  - PUPPET_GEM_VERSION="~> 3.3.0"
+  - PUPPET_GEM_VERSION="~> 3.4.0"
+  - PUPPET_GEM_VERSION="~> 3.5.0"
+  - PUPPET_GEM_VERSION="~> 3.6.0"
+  - PUPPET_GEM_VERSION="~> 3.7.0"
+  - PUPPET_GEM_VERSION="~> 3.8.0"
+  - PUPPET_GEM_VERSION="~> 4.0.0"
+  - PUPPET_GEM_VERSION="~> 4.1.0"
+  - PUPPET_GEM_VERSION="~> 4.2.0"
+  - PUPPET_GEM_VERSION="~> 4.3.0"
+  - PUPPET_GEM_VERSION="~> 4.4.0"
+  - PUPPET_GEM_VERSION="~> 4.5.0"
+  - PUPPET_GEM_VERSION="~> 4.6.0"
+  - PUPPET_GEM_VERSION="~> 4.7.0"
+  - PUPPET_GEM_VERSION="~> 4.8.0"
+matrix:
+  exclude:
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ bundler_args: --without development
 before_install: rm Gemfile.lock || true
 script: "bundle exec rake test"
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,7 @@ matrix:
   exclude:
     - rvm: 2.0.0
       env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.0.0"
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 group :development, :test do
-  gem 'rake',                   :require => false
+  gem 'rake', '< 10.5.0',       :require => false
   gem 'rspec', '< 3.0.0',       :require => false
   gem 'rspec-puppet',           :require => false, :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem 'puppetlabs_spec_helper', '~> 0.4.0', :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ group :development, :test do
   gem 'rake', '< 10.5.0',       :require => false
   gem 'tins', '< 1.6.0',        :require => false
   gem 'mime-types', '< 2.99',   :require => false
+  gem 'json', '< 1.8.3',        :require => false
   gem 'rspec', '< 3.0.0',       :require => false
   gem 'rspec-puppet',           :require => false, :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem 'puppetlabs_spec_helper', '~> 0.4.0', :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "http://rubygems.org"
 group :development, :test do
   gem 'rake', '< 10.5.0',       :require => false
   gem 'tins', '< 1.6.0',        :require => false
+  gem 'mime-types', '~> 2.6, < 2.99', :require => false
   gem 'rspec', '< 3.0.0',       :require => false
   gem 'rspec-puppet',           :require => false, :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem 'puppetlabs_spec_helper', '~> 0.4.0', :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "http://rubygems.org"
 
 group :development, :test do
   gem 'rake', '< 10.5.0',       :require => false
+  gem 'tins', '< 1.6.0',        :require => false
   gem 'rspec', '< 3.0.0',       :require => false
   gem 'rspec-puppet',           :require => false, :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem 'puppetlabs_spec_helper', '~> 0.4.0', :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ group :development, :test do
   gem 'tins', '< 1.6.0',        :require => false
   gem 'mime-types', '< 2.99',   :require => false
   gem 'json', '< 1.8.3',        :require => false
+  gem 'json_pure', '< 2.0.1',   :require => false
   gem 'rspec', '< 3.0.0',       :require => false
   gem 'rspec-puppet',           :require => false, :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem 'puppetlabs_spec_helper', '~> 0.4.0', :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,17 @@
 source "http://rubygems.org"
 
 group :development, :test do
-  gem 'rake', '< 10.5.0',       :require => false
-  gem 'tins', '< 1.6.0',        :require => false
-  gem 'mime-types', '< 2.99',   :require => false
-  gem 'json', '< 1.8.3',        :require => false
-  gem 'json_pure', '< 2.0.1',   :require => false
-  gem 'rspec', '< 3.0.0',       :require => false
-  gem 'rspec-puppet',           :require => false, :git => 'https://github.com/rodjek/rspec-puppet.git'
-  gem 'puppetlabs_spec_helper', '~> 0.4.0', :require => false
-  gem 'puppet-lint',            :require => false
-  gem 'puppet-syntax',          :require => false
-  gem 'travis-lint',            :require => false
-  gem 'simplecov',              :require => false
-  gem 'coveralls',              :require => false
+  gem 'puppetlabs_spec_helper', '>= 1.2.0'
+  gem 'facter', '>= 1.7.0'
+  gem 'rspec-puppet'
+  gem 'puppet-lint', '~> 2.0'
+
+  gem 'rspec',     '~> 2.0'   if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+  gem 'rake',      '~> 10.0'  if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+  gem 'json',      '<= 1.8'   if RUBY_VERSION < '2.0.0'
+  gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'
+  gem 'metadata-json-lint', '0.0.11'   if RUBY_VERSION < '1.9'
+  gem 'metadata-json-lint' if RUBY_VERSION >= '1.9'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "http://rubygems.org"
 group :development, :test do
   gem 'rake', '< 10.5.0',       :require => false
   gem 'tins', '< 1.6.0',        :require => false
-  gem 'mime-types', '~> 2.6, < 2.99', :require => false
+  gem 'mime-types', '< 2.99',   :require => false
   gem 'rspec', '< 3.0.0',       :require => false
   gem 'rspec-puppet',           :require => false, :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem 'puppetlabs_spec_helper', '~> 0.4.0', :require => false

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Sets the `ensure` parameter for the classes' managed resources (defaults to `'pr
 
 Boolean that determines if the group resource is managed by this module (defaults to `true`).
 
+#####`manage_epel`
+
+Boolean that determines if the epel module is included by this module (defaults to `true`).
+
 #####`group_gid`
 
 Sets the mock group's GID (defaults to `'135'`).

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,9 @@ require 'puppet-syntax/tasks/puppet-syntax'
 
 PuppetLint.configuration.send("disable_80chars")
 PuppetLint.configuration.send('disable_quoted_booleans')
+#module autoload format always fails when module directory is in 'username-modulename' format
+#disabling so that automatic test can pass
+PuppetLint.configuration.send('disable_autoloader_layout')
 PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
 PuppetLint.configuration.fail_on_warnings = true
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,7 @@
 class mock (
   $ensure = 'present',
   $manage_group = true,
+  $manage_epel = true,
   $group_gid = '135',
   $group_name = $mock::params::group_name,
   $package_name = $mock::params::package_name,
@@ -12,8 +13,11 @@ class mock (
 
   validate_re($ensure, [ '^present', '^absent' ])
   validate_bool($manage_group)
+  validate_bool($manage_epel)
 
-  include epel
+  if $manage_epel {
+    include epel
+  }
 
   if $manage_group {
     group { 'mock':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,10 +21,10 @@ class mock (
 
   if $manage_group {
     group { 'mock':
-      ensure  => $ensure,
-      name    => $group_name,
-      gid     => $group_gid,
-      before  => Package['mock'],
+      ensure => $ensure,
+      name   => $group_name,
+      gid    => $group_gid,
+      before => Package['mock'],
     }
   }
 

--- a/spec/classes/mock_spec.rb
+++ b/spec/classes/mock_spec.rb
@@ -1,7 +1,12 @@
 require 'spec_helper'
 
 describe 'mock' do
-  let(:facts) {{ :osfamily => 'RedHat' }}
+  let(:facts) do
+    { 
+      :osfamily => 'RedHat', 
+      :puppetversion => Puppet.version, 
+    }
+  end
 
   let(:params) {{}}
 


### PR DESCRIPTION
Add parameter option to allow user to specify if the EPEL repository settings should be managed by this module by including the epel class. This allows this module to be used without conflicts in environments where the EPEL settings are managed by subscription manager in Katello/Satellite. 

The default behavior is unchanged.