### PR TITLE
Epel option pull request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,36 @@
 language: ruby
 bundler_args: --without development
 before_install: rm Gemfile.lock || true
+sudo: false
 script: "bundle exec rake test"
 rvm:
   - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
-  - 2.3.1
 env:
-  - PUPPET_GEM_VERSION="~> 3.1.0"
-  - PUPPET_GEM_VERSION="~> 3.2.0"
-  - PUPPET_GEM_VERSION="~> 3.3.0"
-  - PUPPET_GEM_VERSION="~> 3.4.0"
-  - PUPPET_GEM_VERSION="~> 3.5.0"
-  - PUPPET_GEM_VERSION="~> 3.6.0"
-  - PUPPET_GEM_VERSION="~> 3.7.0"
-  - PUPPET_GEM_VERSION="~> 3.8.0"
-  - PUPPET_GEM_VERSION="~> 4.0.0"
-  - PUPPET_GEM_VERSION="~> 4.1.0"
-  - PUPPET_GEM_VERSION="~> 4.2.0"
-  - PUPPET_GEM_VERSION="~> 4.3.0"
-  - PUPPET_GEM_VERSION="~> 4.4.0"
-  - PUPPET_GEM_VERSION="~> 4.5.0"
-  - PUPPET_GEM_VERSION="~> 4.6.0"
-  - PUPPET_GEM_VERSION="~> 4.7.0"
-  - PUPPET_GEM_VERSION="~> 4.8.0"
+  matrix:
+    - PUPPET_GEM_VERSION="~> 3.1.0"
+    - PUPPET_GEM_VERSION="~> 3.2.0"
+    - PUPPET_GEM_VERSION="~> 3.3.0"
+    - PUPPET_GEM_VERSION="~> 3.4.0"
+    - PUPPET_GEM_VERSION="~> 3.5.0"
+    - PUPPET_GEM_VERSION="~> 3.6.0"
+    - PUPPET_GEM_VERSION="~> 3.7.0"
+    - PUPPET_GEM_VERSION="~> 3.8.0"
 matrix:
+  fast_finish: true
   exclude:
     - rvm: 2.0.0
       env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.0.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.2.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.3.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.4.0"
+
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,31 @@ rvm:
   - 1.8.7
   - 1.9.3
   - 2.0.0
+  - 2.1.0
+  - 2.3.1
 env:
-  - PUPPET_GEM_VERSION="~> 2.7.0"
   - PUPPET_GEM_VERSION="~> 3.1.0"
   - PUPPET_GEM_VERSION="~> 3.2.0"
   - PUPPET_GEM_VERSION="~> 3.3.0"
   - PUPPET_GEM_VERSION="~> 3.4.0"
   - PUPPET_GEM_VERSION="~> 3.5.0"
+  - PUPPET_GEM_VERSION="~> 3.6.0"
+  - PUPPET_GEM_VERSION="~> 3.7.0"
+  - PUPPET_GEM_VERSION="~> 3.8.0"
+  - PUPPET_GEM_VERSION="~> 4.0.0"
+  - PUPPET_GEM_VERSION="~> 4.1.0"
+  - PUPPET_GEM_VERSION="~> 4.2.0"
+  - PUPPET_GEM_VERSION="~> 4.3.0"
+  - PUPPET_GEM_VERSION="~> 4.4.0"
+  - PUPPET_GEM_VERSION="~> 4.5.0"
+  - PUPPET_GEM_VERSION="~> 4.6.0"
+  - PUPPET_GEM_VERSION="~> 4.7.0"
+  - PUPPET_GEM_VERSION="~> 4.8.0"
 matrix:
   exclude:
     - rvm: 2.0.0
       env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 2.7.0"
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 2.7.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.0.0"
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,17 @@
 source "http://rubygems.org"
 
 group :development, :test do
-  gem 'rake',                   :require => false
-  gem 'rspec', '< 3.0.0',       :require => false
-  gem 'rspec-puppet',           :require => false, :git => 'https://github.com/rodjek/rspec-puppet.git'
-  gem 'puppetlabs_spec_helper', '~> 0.4.0', :require => false
-  gem 'puppet-lint',            :require => false
-  gem 'puppet-syntax',          :require => false
-  gem 'travis-lint',            :require => false
-  gem 'simplecov',              :require => false
-  gem 'coveralls',              :require => false
+  gem 'puppetlabs_spec_helper', '>= 1.2.0'
+  gem 'facter', '>= 1.7.0'
+  gem 'rspec-puppet'
+  gem 'puppet-lint', '~> 2.0'
+
+  gem 'rspec',     '~> 2.0'   if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+  gem 'rake',      '~> 10.0'  if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+  gem 'json',      '<= 1.8'   if RUBY_VERSION < '2.0.0'
+  gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'
+  gem 'metadata-json-lint', '0.0.11'   if RUBY_VERSION < '1.9'
+  gem 'metadata-json-lint' if RUBY_VERSION >= '1.9'
 end
 
 group :development do

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Sets the `ensure` parameter for the classes' managed resources (defaults to `'pr
 
 Boolean that determines if the group resource is managed by this module (defaults to `true`).
 
+#####`manage_epel`
+
+Boolean that determines if the epel module is included by this module (defaults to `true`).
+
 #####`group_gid`
 
 Sets the mock group's GID (defaults to `'135'`).

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,9 @@ require 'puppet-syntax/tasks/puppet-syntax'
 
 PuppetLint.configuration.send("disable_80chars")
 PuppetLint.configuration.send('disable_quoted_booleans')
+#module autoload format always fails when module directory is in 'username-modulename' format
+#disabling so that automatic test can pass
+PuppetLint.configuration.send('disable_autoloader_layout')
 PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
 PuppetLint.configuration.fail_on_warnings = true
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,7 @@
 class mock (
   $ensure = 'present',
   $manage_group = true,
+  $manage_epel = true,
   $group_gid = '135',
   $group_name = $mock::params::group_name,
   $package_name = $mock::params::package_name,
@@ -12,15 +13,18 @@ class mock (
 
   validate_re($ensure, [ '^present', '^absent' ])
   validate_bool($manage_group)
+  validate_bool($manage_epel)
 
-  include epel
+  if $manage_epel {
+    include epel
+  }
 
   if $manage_group {
     group { 'mock':
-      ensure  => $ensure,
-      name    => $group_name,
-      gid     => $group_gid,
-      before  => Package['mock'],
+      ensure => $ensure,
+      name   => $group_name,
+      gid    => $group_gid,
+      before => Package['mock'],
     }
   }
 

--- a/spec/classes/mock_spec.rb
+++ b/spec/classes/mock_spec.rb
@@ -66,6 +66,7 @@ describe 'mock' do
   # Test verify_boolean parameters
   [
     'manage_group',
+    'manage_epel',
   ].each do |param|
     context "with #{param} => 'foo'" do
       let(:params) {{ param.to_sym => 'foo' }}


### PR DESCRIPTION
Clean resubmit of pull request to add a parameter to disable including the epel module, for use cases when EPEL settings are manged elsewhere, e.g. through Satellite/Katello.

The tests are fixed, after correcting the gem dependencies through the known-good example at https://github.com/ghoneycutt/puppet-module-ssh. The module can now be tested for all versions of Puppet 3. The submitted commit history includes the settings needed to test against Puppet 4, but the versions of tahnma/epel allowed in the module has its own problems passing testing for Puppet 4/Puppet 3 with Future Parser. Those can likely be solved by changing the accepted ranges of versions to include the latest.